### PR TITLE
테스트 코드, 잘못 표현된 부분 리팩토링

### DIFF
--- a/src/main/java/org/yunho/boardservice/domain/AuditingFields.java
+++ b/src/main/java/org/yunho/boardservice/domain/AuditingFields.java
@@ -23,18 +23,18 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy;
+    protected String createdBy;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy;
+    protected String modifiedBy;
 }

--- a/src/test/java/org/yunho/boardservice/service/ArticleServiceTest.java
+++ b/src/test/java/org/yunho/boardservice/service/ArticleServiceTest.java
@@ -299,7 +299,7 @@ class ArticleServiceTest {
         then(hashtagService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다")
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다.")
     @Test
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
@@ -320,7 +320,7 @@ class ArticleServiceTest {
         then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
     }
 
-    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다.")
     @Test
     void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
         // Given
@@ -335,7 +335,7 @@ class ArticleServiceTest {
         then(articleRepository).should().count();
     }
 
-    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다")
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
     @Test
     void givenNothing_whenCalling_thenReturnsHashtags() {
         // Given


### PR DESCRIPTION
이 pr은 테스트코드의 품질을 관리하기 위해 일부 테스트 제목을 다른 테스트 제목과 일관된 형태로 수정하고,
`AuditingFields`의 필드 접근제어자를 추상 클래스에 맞게 `protected`로 수정한다.

This closes #69 