### PR TITLE
게시글 (페이지네이션 + 정렬) 로직 버그

### DIFF
--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -63,19 +63,19 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                     th:text="'previous'"
-                    th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                    th:href="@{/articles(page=${articles.number - 1}, sort=${param.sort}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                     th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
             />
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                 <attr sel="a"
                         th:text="${pageNumber + 1}"
-                        th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                        th:href="@{/articles(page=${pageNumber}, sort=${param.sort}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                         th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                 />
             </attr>
             <attr sel="li[2]/a"
                     th:text="'next'"
-                    th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                    th:href="@{/articles(page=${articles.number + 1}, sort=${param.sort}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                     th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>

--- a/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -56,19 +56,19 @@
             <attr sel="ul">
                 <attr sel="li[0]/a"
                       th:text="'previous'"
-                      th:href="@{/articles(page=${articles.number - 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:href="@{/articles(page=${articles.number - 1}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
                 />
                 <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                     <attr sel="a"
                           th:text="${pageNumber + 1}"
-                          th:href="@{/articles(page=${pageNumber}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                          th:href="@{/articles(page=${pageNumber}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
                           th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                     />
                 </attr>
                 <attr sel="li[2]/a"
                       th:text="'next'"
-                      th:href="@{/articles(page=${articles.number + 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:href="@{/articles(page=${articles.number + 1}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
                 />
             </attr>


### PR DESCRIPTION
정렬 -> 페이지 변경 시에 정렬이 사라지는 버그 해결