### PR TITLE
추가 테스트 코드 작성

### DIFF
--- a/src/main/java/org/yunho/boardservice/service/HashtagService.java
+++ b/src/main/java/org/yunho/boardservice/service/HashtagService.java
@@ -34,7 +34,7 @@ public class HashtagService {
         Set<String> result = new HashSet<>();
 
         while (matcher.find()) {
-            result.add(matcher.group().replace("#", ""));
+            result.add(matcher.group().replace("#", "").toLowerCase());
         }
 
         return Set.copyOf(result);

--- a/src/test/java/org/yunho/boardservice/integration/ArticleIntegrationTest.java
+++ b/src/test/java/org/yunho/boardservice/integration/ArticleIntegrationTest.java
@@ -1,0 +1,39 @@
+package org.yunho.boardservice.integration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("통합테스트 - 게시글")
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+public class ArticleIntegrationTest {
+
+    private final MockMvc mvc;
+
+    public ArticleIntegrationTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("게시글 페이지를 요청하면, 게시글 뷰를 반환한다.")
+    @Test
+    void testGivenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+    }
+
+}

--- a/src/test/java/org/yunho/boardservice/repository/HashtagRepositoryTest.java
+++ b/src/test/java/org/yunho/boardservice/repository/HashtagRepositoryTest.java
@@ -1,0 +1,34 @@
+package org.yunho.boardservice.repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@DisplayName("[Repository] 해시태그 테스트")
+@DataJpaTest
+class HashtagRepositoryTest {
+
+    @Autowired private HashtagRepository sut;
+
+    @DisplayName("해시태그가 없으면, 예외를 던진다.")
+    @Test
+    void givenHashtagId_whenHashTagDoesNotExist_thenThrowsException() {
+        // Given
+        Long hashtagId = 1L;
+        sut.deleteById(hashtagId);
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getReferenceById(hashtagId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(JpaObjectRetrievalFailureException.class)
+                .hasRootCauseInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/org/yunho/boardservice/service/ArticleServiceTest.java
+++ b/src/test/java/org/yunho/boardservice/service/ArticleServiceTest.java
@@ -5,6 +5,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -210,13 +211,15 @@ class ArticleServiceTest {
         // Given
         ArticleDto dto = createArticleDto();
         Set<String> expectedHashtagNames = Set.of("java", "spring");
-        Set<Hashtag> expectedHashtags = new HashSet<>();
-        expectedHashtags.add(createHashtag("java"));
+        Set<Hashtag> expectedExistingHashtags = new HashSet<>();
+        expectedExistingHashtags.add(createHashtag("java"));
+        Article expectedArticle = createArticle();
+        ArgumentCaptor<Article> articleCaptor = ArgumentCaptor.forClass(Article.class);
 
         given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(createUserAccount());
         given(hashtagService.parseHashtagNames(dto.content())).willReturn(expectedHashtagNames);
-        given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedHashtags);
-        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
+        given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedExistingHashtags);
+        given(articleRepository.save(any(Article.class))).willReturn(expectedArticle);
 
         // When
         sut.saveArticle(dto);
@@ -225,7 +228,13 @@ class ArticleServiceTest {
         then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
         then(hashtagService).should().parseHashtagNames(dto.content());
         then(hashtagService).should().findHashtagsByNames(expectedHashtagNames);
-        then(articleRepository).should().save(any(Article.class));
+        then(articleRepository).should().save(articleCaptor.capture());
+        assertThat(articleCaptor.getValue())
+                .hasFieldOrPropertyWithValue("title", dto.title())
+                .hasFieldOrPropertyWithValue("content", dto.content())
+                .extracting("hashtags", as(InstanceOfAssertFactories.COLLECTION))
+                .extracting("hashtagName")
+                .containsExactlyInAnyOrderElementsOf(expectedHashtagNames);
     }
 
     @DisplayName("게시글의 수정 정보를 입력하면, 게시글을 수정한다.")

--- a/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
+++ b/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
@@ -31,10 +31,10 @@ class HashtagServiceTest {
 
     @Mock private HashtagRepository hashtagRepository;
 
-    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 대소문자를 무시하고 반환한다.")
     @MethodSource
     @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
-    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) {
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNamesIgnoringCase(String input, Set<String> expected) {
         // Given
 
         // When
@@ -45,7 +45,7 @@ class HashtagServiceTest {
         then(hashtagRepository).shouldHaveNoInteractions();
     }
 
-    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNamesIgnoringCase() {
         return Stream.of(
                 arguments(null, Set.of()),
                 arguments("", Set.of()),
@@ -57,6 +57,7 @@ class HashtagServiceTest {
                 arguments("java#", Set.of()),
                 arguments("ja#va", Set.of("va")),
                 arguments("#java", Set.of("java")),
+                arguments("#Java", Set.of("java")),
                 arguments("#java_spring", Set.of("java_spring")),
                 arguments("#java-spring", Set.of("java")),
                 arguments("#_java_spring", Set.of("_java_spring")),
@@ -64,6 +65,7 @@ class HashtagServiceTest {
                 arguments("#_java_spring__", Set.of("_java_spring__")),
                 arguments("#java#spring", Set.of("java", "spring")),
                 arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java #Spring", Set.of("java", "spring")),
                 arguments("#java  #spring", Set.of("java", "spring")),
                 arguments("#java   #spring", Set.of("java", "spring")),
                 arguments("#java     #spring", Set.of("java", "spring")),
@@ -79,6 +81,7 @@ class HashtagServiceTest {
                 arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
                 arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
                 arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#JAVA#Java#sPRINg#부트", Set.of("java", "spring", "부트")),
                 arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
                 arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
                 arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),

--- a/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
+++ b/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.BDDMockito.*;
 
@@ -136,6 +137,21 @@ class HashtagServiceTest {
         // Then
         then(hashtagRepository).should().getReferenceById(hashtagId);
         then(hashtagRepository).should(times(0)).delete(hashtag);
+    }
+
+    @DisplayName("존재하지 않는 해시태그 ID가 주어지면, 예외를 던진다.")
+    @Test
+    void givenNonexistentHashtagId_whenDeleting_thenThrowsException() {
+        // Given
+        Long hashtagId = -123L;
+        given(hashtagRepository.getReferenceById(hashtagId)).willThrow(RuntimeException.class);
+
+        // When
+        Throwable t = catchThrowable(() -> sut.deleteHashtagWithoutArticles(hashtagId));
+
+        // Then
+        assertThat(t).isInstanceOf(RuntimeException.class);
+        then(hashtagRepository).should().getReferenceById(hashtagId);
     }
 
 }

--- a/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
+++ b/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
@@ -18,8 +18,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 
 @DisplayName("비즈니스 로직 - 해시태그")
 @ExtendWith(MockitoExtension.class)
@@ -101,6 +100,23 @@ class HashtagServiceTest {
         // Then
         assertThat(hashtags).hasSize(2);
         then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+
+    @DisplayName("연관된 게시글이 없는 해시태그 ID가 주어지면, 해시태그를 삭제한다.")
+    @Test
+    void givenHashtagId_whenDeletingHashtagWithoutRelevantArticle_thenDeletesHashtagOnly() {
+        // Given
+        Long hashtagId = 1L;
+        Hashtag hashtag = Hashtag.of("java");
+        given(hashtagRepository.getReferenceById(hashtagId)).willReturn(hashtag);
+        willDoNothing().given(hashtagRepository).delete(hashtag);
+
+        // When
+        sut.deleteHashtagWithoutArticles(hashtagId);
+
+        // Then
+        then(hashtagRepository).should().getReferenceById(hashtagId);
+        then(hashtagRepository).should().delete(hashtag);
     }
 
 }

--- a/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
+++ b/src/test/java/org/yunho/boardservice/service/HashtagServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.yunho.boardservice.domain.Article;
 import org.yunho.boardservice.domain.Hashtag;
 import org.yunho.boardservice.repository.HashtagRepository;
 
@@ -117,6 +119,23 @@ class HashtagServiceTest {
         // Then
         then(hashtagRepository).should().getReferenceById(hashtagId);
         then(hashtagRepository).should().delete(hashtag);
+    }
+
+    @DisplayName("연관된 게시글이 있는 해시태그 ID가 주어지면, 해시태그를 삭제하지 않는다.")
+    @Test
+    void givenHashtagId_whenDeletingHashtagWithRelevantArticle_thenDoesNotDeleteHashtag() {
+        // Given
+        Long hashtagId = 1L;
+        Hashtag hashtag = Hashtag.of("java");
+        ReflectionTestUtils.setField(hashtag, "articles", Set.of(Article.of(null, null, null)));
+        given(hashtagRepository.getReferenceById(hashtagId)).willReturn(hashtag);
+
+        // When
+        sut.deleteHashtagWithoutArticles(hashtagId);
+
+        // Then
+        then(hashtagRepository).should().getReferenceById(hashtagId);
+        then(hashtagRepository).should(times(0)).delete(hashtag);
     }
 
 }


### PR DESCRIPTION
기존 코드에서 부족한 테스트를 파악하고, 몇 가지 테스트를 추가로 작성

테스트 작성 중 해시태그의 대소문자를 가리는 문제를 발견.
따라서 게시글을 저장할 때, 함께 저장하는 해시태그의 대소문자를 가리지 않도록 기능을 추가로 수정하였음

This closes #91 